### PR TITLE
Fix: add 'px' to grid line styling

### DIFF
--- a/src/canvasApi.js
+++ b/src/canvasApi.js
@@ -97,8 +97,11 @@ export function dots(dots = true, transparentBackground = false, force = false) 
     var ox = globalScope.ox % scale; // offset
     var oy = globalScope.oy % scale; // offset
 
-    document.getElementById('backgroundArea').style.left = (ox - scale) / DPR;
-    document.getElementById('backgroundArea').style.top = (oy - scale) / DPR;
+    if (backgroundArea.canvas) {
+        backgroundArea.canvas.style.left = `${(ox - scale) / DPR}px`;
+        backgroundArea.canvas.style.top = `${(oy - scale) / DPR}px`;
+    }
+
     if (globalScope.scale === simulationArea.prevScale && !force) return;
 
     if (!backgroundArea.context) return;


### PR DESCRIPTION
Fixes #4 

**Describe the changes you have made in this PR -**
- added 'px' at the end of background canvas styling.

**Screenshots**

https://user-images.githubusercontent.com/56310902/160241118-6b98db3e-cb75-41f3-8ddf-97d9994dd733.mp4
